### PR TITLE
Improved text representations

### DIFF
--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -74,12 +74,13 @@ Base.showcompact(io::IO, grid::AbstractGrid) = print(io, "$(typeof(grid)) with $
 Base.show(io::IO, grid::AbstractGrid) = Base.showcompact(io, grid)
 
 # showall returns a valid constructor incantation - it will be called when repr is called on a grid
-function Base.showall(io::IO, grid::SimplexGrid)
-    argstring = ""
+function Base.showall(io::IO, grid::AbstractGrid)
+    print(io, "$(typeof(grid))(")
     for v in grid.cutPoints
-        argstring = string(argstring, repr(v), ",")
+        show(io, v)
+        print(io, ',')
     end
-    print(io, "$(typeof(grid))($argstring)")
+    print(io, ')')
 end
 
 function ind2x(grid::AbstractGrid, ind::Int)

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -1,6 +1,6 @@
 module GridInterpolations
 
-export AbstractGrid, RectangleGrid, SimplexGrid, dimensions, length, show, ind2x, ind2x!, interpolate, maskedInterpolate, interpolants
+export AbstractGrid, RectangleGrid, SimplexGrid, dimensions, length, ind2x, ind2x!, interpolate, maskedInterpolate, interpolants
 
 abstract AbstractGrid
 
@@ -70,7 +70,17 @@ function SimplexGrid(cutPoints::Vector{Float64}...)
     SimplexGrid(myCutPoints, cut_counts, cuts, index, weight, x_p, ihi, ilo, n_ind)
 end
 
-Base.show(io::IO, grid::AbstractGrid) = show(io, grid.cutPoints)
+Base.showcompact(io::IO, grid::AbstractGrid) = print(io, "$(typeof(grid)) with $(length(grid)) points")
+Base.show(io::IO, grid::AbstractGrid) = Base.showcompact(io, grid)
+
+# showall returns a valid constructor incantation - it will be called when repr is called on a grid
+function Base.showall(io::IO, grid::SimplexGrid)
+    argstring = ""
+    for v in grid.cutPoints
+        argstring = string(argstring, repr(v), ",")
+    end
+    print(io, "$(typeof(grid))($argstring)")
+end
 
 function ind2x(grid::AbstractGrid, ind::Int)
     ndims = dimensions(grid)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,6 +157,12 @@ function simplexMagic(NDISC::Int=20, NPOINTS::Int=3, checkFileName::String="", e
 
 end
 
+# constructs a new grid from repr output and tests to see if it's the same
+function reprConstruct()
+    g1 = SimplexGrid([1.0, 2.0, 3.0], [1.0, 2.0, 3.0])
+    g2 = eval(parse(repr(g1)))
+    return g1.cutPoints == g2.cutPoints
+end
 
 function mapPt(pt::Int, NPOINTS::Int, NDISC::Int)
     return pt * (NPOINTS-1) / NDISC + 1
@@ -167,6 +173,8 @@ end
 #@test compareToGrid(:extrapNeg)==true
 
 @test simplexMagic()==true
+
+@test reprConstruct()==true
 
 include(joinpath(Pkg.dir("GridInterpolations"), "src", "interpBenchmarks.jl"))
 rectangleBenchmark(quiet=true)


### PR DESCRIPTION
Improved text representations of grids:
`showcompact` simply indicates the type and number of nodes; `show` mimics this behavior.
`showall` returns a valid constructor incantation (which is a minimal representation of the grid). This is also what is used when `repr` is called.

Also, apparently you don't have to export `Base.show` and siblings (maybe I'm wrong about this, but it seems to work)