### PR TITLE
Add function to get vertices of grid

### DIFF
--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -318,18 +318,19 @@ function interpolants(grid::SimplexGrid, x::Vector)
     return index::Vector{Int}, weight::Vector{Float64}
 end
 
-# Returns a vector of length num_vertices with the n-dimensional vertices in deterministic order
+# Returns a matrix of size (num_vertices x grid_dimension)
+# where the ith row represents the vertex corresponding to the ith index of grid data 
 function vertices(grid::AbstractGrid)
 
     vertex_list::Array{Float64,2} = Array{Float64,2}(length(grid),dimensions(grid))
     n_dims::Int = dimensions(grid)
 
-    # Iterate over number of vertices in grid
+    # Iterate over the number of vertices in a grid
     for idx = 1 : length(grid)
         this_idx::Int = idx-1
 
         # Get the correct index into each dimension
-        # And populate vertex index with corresponding cut point
+        # and populate vertex index with corresponding cut point
         for j = 1 : n_dims
             cut_idx::Int = this_idx % grid.cut_counts[j]
             this_idx = div(this_idx,grid.cut_counts[j])

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -317,15 +317,19 @@ function interpolants(grid::SimplexGrid, x::Vector)
     return index::Vector{Int}, weight::Vector{Float64}
 end
 
-# Returns a Vector of length num_vertices with the n-dimensional vertices in deterministic order
+# Returns a vector of length num_vertices with the n-dimensional vertices in deterministic order
 function vertices(grid::AbstractGrid)
 
     vertex_list = Vector{Vector{Float64}}(length(grid))
     n_dims::Int = dimensions(grid)
 
+    # Iterate over number of vertices in grid
     for idx = 1 : length(grid)
         vertex_list[idx] = zeros(n_dims)
         this_idx = idx-1
+
+        # Get the correct index into each dimension
+        # And populate vertex index with corresponding cut point
         for j = 1 : n_dims
             cut_idx = this_idx % grid.cut_counts[j]
             this_idx = div(this_idx,grid.cut_counts[j])

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -317,6 +317,26 @@ function interpolants(grid::SimplexGrid, x::Vector)
     return index::Vector{Int}, weight::Vector{Float64}
 end
 
+# Returns a Vector of length num_vertices with the n-dimensional vertices in deterministic order
+function vertices(grid::AbstractGrid)
+
+    vertex_list = fill!(Vector{Vector{Float64}}(length(grid)), zeros(dimensions(grid)));
+    n_dims::Int = dimensions(grid)
+
+    for idx = 1 : length(grid)
+        this_idx = idx-1
+
+        for j = 1 : n_dims
+            cut_idx = this_idx % grid.cuts[j]
+            this_idx = div(this_idx,grid.cuts[j])
+
+            vertex_list[idx][j] = cut_idx+1
+        end
+    end
+
+    return vertex_list
+end
+
 
 
 #################### sortperm! is included in Julia v0.4 ###################

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -321,20 +321,19 @@ end
 # Returns a vector of length num_vertices with the n-dimensional vertices in deterministic order
 function vertices(grid::AbstractGrid)
 
-    vertex_list = Vector{Vector{Float64}}(length(grid))
+    vertex_list::Array{Float64,2} = Array{Float64,2}(length(grid),dimensions(grid))
     n_dims::Int = dimensions(grid)
 
     # Iterate over number of vertices in grid
     for idx = 1 : length(grid)
-        vertex_list[idx] = zeros(n_dims)
-        this_idx = idx-1
+        this_idx::Int = idx-1
 
         # Get the correct index into each dimension
         # And populate vertex index with corresponding cut point
         for j = 1 : n_dims
-            cut_idx = this_idx % grid.cut_counts[j]
+            cut_idx::Int = this_idx % grid.cut_counts[j]
             this_idx = div(this_idx,grid.cut_counts[j])
-            vertex_list[idx][j] = grid.cutPoints[j][cut_idx+1]
+            vertex_list[idx,j] = grid.cutPoints[j][cut_idx+1]
         end
     end
 

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -1,7 +1,7 @@
 module GridInterpolations
 
 
-export AbstractGrid, RectangleGrid, SimplexGrid, dimensions, length, label, ind2x, ind2x!, interpolate, maskedInterpolate, interpolants
+export AbstractGrid, RectangleGrid, SimplexGrid, dimensions, length, label, ind2x, ind2x!, interpolate, maskedInterpolate, interpolants, vertices
 
 abstract type AbstractGrid end
 
@@ -320,17 +320,16 @@ end
 # Returns a Vector of length num_vertices with the n-dimensional vertices in deterministic order
 function vertices(grid::AbstractGrid)
 
-    vertex_list = fill!(Vector{Vector{Float64}}(length(grid)), zeros(dimensions(grid)));
+    vertex_list = Vector{Vector{Float64}}(length(grid))
     n_dims::Int = dimensions(grid)
 
     for idx = 1 : length(grid)
+        vertex_list[idx] = zeros(n_dims)
         this_idx = idx-1
-
         for j = 1 : n_dims
-            cut_idx = this_idx % grid.cuts[j]
-            this_idx = div(this_idx,grid.cuts[j])
-
-            vertex_list[idx][j] = cut_idx+1
+            cut_idx = this_idx % grid.cut_counts[j]
+            this_idx = div(this_idx,grid.cut_counts[j])
+            vertex_list[idx][j] = grid.cutPoints[j][cut_idx+1]
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,22 @@ end
 @test_throws ErrorException test_ordering( RectangleGrid([2,5], [18,15,12]) )
 @test_throws ErrorException test_ordering( SimplexGrid([2,5], [18,15,12]) )
 
+# tests the order of vertices returned by vertices()
+# by comparing against ind2x for each unrolled index
+function test_vertices_ordering(grid)
+
+    grid_verts = vertices(grid)
+
+    @test length(grid_verts) == length(grid)
+
+    for i = 1 : length(grid)
+        @test grid_verts[i] == ind2x(grid,i)
+    end
+
+    return true
+end
+@test test_vertices_ordering( RectangleGrid([2,5], [12,15,18]) ) == true
+@test test_vertices_ordering( SimplexGrid([1,4,6,10], [8,12,17]) ) == true
 
 
 include(joinpath(@__DIR__, "..", "src", "interpBenchmarks.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,10 +319,10 @@ function test_vertices_ordering(grid)
 
     grid_verts = vertices(grid)
 
-    @test length(grid_verts) == length(grid)
+    @test length(grid_verts) == length(grid)*dimensions(grid)
 
     for i = 1 : length(grid)
-        @test grid_verts[i] == ind2x(grid,i)
+        @test grid_verts[i,:] == ind2x(grid,i)
     end
 
     return true


### PR DESCRIPTION
The function `vertices(::AbstractGrid` is added in `GridInterpolations.jl` to allow the caller to obtain a `Vector` of size `length(grid)` where each element is one of the vertices of the grid. The order of vertices is deterministically generated.

E.g. 
```
julia> grid = RectangleGrid([0., 0.5],[0., 0.5, 1.])
GridInterpolations.RectangleGrid with 6 points

julia> vs = vertices(grid)
6-element Array{Array{Float64,1},1}:
 [0.0, 0.0]
 [0.5, 0.0]
 [0.0, 0.5]
 [0.5, 0.5]
 [0.0, 1.0]
 [0.5, 1.0]
```