### PR TITLE
any(isnan.(x)) -> any(isnan, x)

### DIFF
--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -162,7 +162,7 @@ function interpolate(grid::AbstractGrid, data::DenseArray, x::AbstractVector)
 end
 
 function interpolants(grid::RectangleGrid, x::AbstractVector)
-    if any(isnan.(x))
+    if any(map(isnan, x))
         throw(DomainError("Input contains NaN!"))
     end
     cut_counts = grid.cut_counts

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -162,7 +162,7 @@ function interpolate(grid::AbstractGrid, data::DenseArray, x::AbstractVector)
 end
 
 function interpolants(grid::RectangleGrid, x::AbstractVector)
-    if any(isnan(t) for t in x)
+    if any(isnan, x)
         throw(DomainError("Input contains NaN!"))
     end
     cut_counts = grid.cut_counts

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -162,7 +162,7 @@ function interpolate(grid::AbstractGrid, data::DenseArray, x::AbstractVector)
 end
 
 function interpolants(grid::RectangleGrid, x::AbstractVector)
-    if any(map(isnan, x))
+    if any(isnan(t) for t in x)
         throw(DomainError("Input contains NaN!"))
     end
     cut_counts = grid.cut_counts


### PR DESCRIPTION
For some reason this is much faster
```
julia> x = [1.0, 4.0, NaN, 3.0]

julia> @benchmark any(isnan.($x))
BenchmarkTools.Trial: 
  memory estimate:  4.31 KiB
  allocs estimate:  3
  --------------
  minimum time:     535.708 ns (0.00% GC)
  median time:      608.789 ns (0.00% GC)
  mean time:        1.256 μs (17.10% GC)
  maximum time:     224.575 μs (99.41% GC)
  --------------
  samples:          10000
  evals/sample:     178

julia> @benchmark any(map(isnan, $x))
BenchmarkTools.Trial: 
  memory estimate:  112 bytes
  allocs estimate:  2
  --------------
  minimum time:     32.824 ns (0.00% GC)
  median time:      36.619 ns (0.00% GC)
  mean time:        47.285 ns (16.65% GC)
  maximum time:     40.261 μs (99.81% GC)
  --------------
  samples:          10000
  evals/sample:     989
```