### PR TITLE
Improved benchmarking using BenchmarkTools

### DIFF
--- a/bench/Project.toml
+++ b/bench/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+GridInterpolations = "bb4c363b-b914-514b-8517-4eb369bc008a"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -8,40 +8,45 @@ function benchmark_interpolate(grid, data, rand_points)
     end
 end
 
-function benchmark(GridType::Type, n_dims::Int=6, n_points_per_dim::Int=15, n_rand_points::Int=100)
+function benchmark(GridType::Type, n_dims::Int; n_points_per_dim::Int=15, n_rand_points::Int=100, verbosity::Int=1)
 
     # construct grid
     grid = GridType((range(0, 1, length=n_points_per_dim) for _ in 1:n_dims)...)
     rand_points = rand(n_dims, n_rand_points)
     rand_data = rand(length(grid))
 
-    println("Benchmarking interpolation on $(label(grid))")
-    println("dimensionality:          $(n_dims)")
-    println("points per dimension:    $(n_points_per_dim)")
-    println("number of random points: $(n_rand_points)")
+    trial = @benchmark benchmark_interpolate($grid, $rand_data, $rand_points) samples=10000
 
-    t = @benchmark benchmark_interpolate($grid, $rand_data, $rand_points) samples=10000
-    trial_estimate = median(t)
-    println(trial_estimate)
+    if verbosity > 0
+        println("Benchmarking interpolation on $(label(grid))")
+        println("dimensionality:          $(n_dims)")
+        println("points per dimension:    $(n_points_per_dim)")
+        println("number of random points: $(n_rand_points)")
+        if verbosity > 1
+            show(stdout, MIME"text/plain"(), trial)  # make sure printing is verbose by using MIME
+        else
+            println("\n", trial)
+        end
+        println("\n--------------------------------------------------")
+    end
 
-    println("--------------------------------------------------")
-
-    return median(t)
+    return trial
 end
 
-for ndims in 1:10
+verbosity = 1
+for ndims in 1:6
 
     println("\n##################################################")
-    println("### SUMMARY (ndims = $(ndims))")
+    println("### Benchmark for ndims = $(ndims)")
     println("##################################################")
 
-    trial_estimate_rectangle = benchmark(RectangleGrid, ndims)
-    trial_estimate_simplex = benchmark(SimplexGrid, ndims)
+    trial_rectangle = benchmark(RectangleGrid, ndims; verbosity=verbosity)
+    trial_simplex = benchmark(SimplexGrid, ndims; verbosity=verbosity)
 
     # println(ratio(trial_estimate_rectangle, trial_estimate_simplex))
     println(
         "RectangleGrid vs SimplexGrid: ",
-        judge(trial_estimate_rectangle, trial_estimate_simplex)
+        judge(median(trial_rectangle), median(trial_simplex))
     )
     println("##################################################\n")
 

--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -1,0 +1,48 @@
+using GridInterpolations
+using Statistics
+using BenchmarkTools
+
+function benchmark_interpolate(grid, data, rand_points)
+    for point in eachcol(rand_points)
+        interpolate(grid, data, point)
+    end
+end
+
+function benchmark(GridType::Type, n_dims::Int=6, n_points_per_dim::Int=15, n_rand_points::Int=100)
+
+    # construct grid
+    grid = GridType((range(0, 1, length=n_points_per_dim) for _ in 1:n_dims)...)
+    rand_points = rand(n_dims, n_rand_points)
+    rand_data = rand(length(grid))
+
+    println("Benchmarking interpolation on $(label(grid))")
+    println("dimensionality:          $(n_dims)")
+    println("points per dimension:    $(n_points_per_dim)")
+    println("number of random points: $(n_rand_points)")
+
+    t = @benchmark benchmark_interpolate($grid, $rand_data, $rand_points) samples=10000
+    trial_estimate = median(t)
+    println(trial_estimate)
+
+    println("--------------------------------------------------")
+
+    return median(t)
+end
+
+for ndims in 1:10
+
+    println("\n##################################################")
+    println("### SUMMARY (ndims = $(ndims))")
+    println("##################################################")
+
+    trial_estimate_rectangle = benchmark(RectangleGrid, ndims)
+    trial_estimate_simplex = benchmark(SimplexGrid, ndims)
+
+    # println(ratio(trial_estimate_rectangle, trial_estimate_simplex))
+    println(
+        "RectangleGrid vs SimplexGrid: ",
+        judge(trial_estimate_rectangle, trial_estimate_simplex)
+    )
+    println("##################################################\n")
+
+end


### PR DESCRIPTION
Not sure what exactly the current benchmarking script is benchmarking, but I tried to reverse-engineer the benchmark code and use `BenchmarkTools` instead.

If we agree on the new benchmarking function, `interpBenchmarks.jl` could be deleted.

Also, in the current setup the condition

```
        abs(nPointsPerDim^i - nPoints) > marginoferror*nPoints
```
 evaluates to false for `i > 6` (but it is run for `i=1:1000` from `compareSpeedUp(1000,...))`, where `i` is the variable representing `nDims`. The new version only loops for `i=1:6`.

More input on how to improve the benchmarking functionality is welcome.