### PR TITLE
Ind2x mvec

### DIFF
--- a/bench/benchmark.jl
+++ b/bench/benchmark.jl
@@ -2,20 +2,20 @@ using GridInterpolations
 using Statistics
 using BenchmarkTools
 
-function benchmark_interpolate(grid, data, rand_points)
+function _benchmark_interpolate(grid, data, rand_points)
     for point in eachcol(rand_points)
         interpolate(grid, data, point)
     end
 end
 
-function benchmark(GridType::Type, n_dims::Int; n_points_per_dim::Int=15, n_rand_points::Int=100, verbosity::Int=1)
+function benchmark_interpolate(GridType::Type, n_dims::Int; n_points_per_dim::Int=15, n_rand_points::Int=100, verbosity::Int=1)
 
     # construct grid
     grid = GridType((range(0, 1, length=n_points_per_dim) for _ in 1:n_dims)...)
     rand_points = rand(n_dims, n_rand_points)
     rand_data = rand(length(grid))
 
-    trial = @benchmark benchmark_interpolate($grid, $rand_data, $rand_points) samples=10000
+    trial = @benchmark _benchmark_interpolate($grid, $rand_data, $rand_points) samples=10000
 
     if verbosity > 0
         println("Benchmarking interpolation on $(label(grid))")
@@ -33,21 +33,41 @@ function benchmark(GridType::Type, n_dims::Int; n_points_per_dim::Int=15, n_rand
     return trial
 end
 
-verbosity = 1
-for ndims in 1:6
+function _benchmark_ind2x(grid, indices)
+    x = zeros(ndims(grid))
+    for i in indices
+        x += ind2x(grid, i)
+    end
+end
 
-    println("\n##################################################")
-    println("### Benchmark for ndims = $(ndims)")
-    println("##################################################")
+function benchmark_ind2x(n_dims=6, n_points_per_dim=10)
+    grid = RectangleGrid((range(0, 1, length=n_points_per_dim) for _ in 1:n_dims)...)
+    trial = @benchmark _benchmark_ind2x($grid, $(1:length(grid))) samples=1000
+end
 
-    trial_rectangle = benchmark(RectangleGrid, ndims; verbosity=verbosity)
-    trial_simplex = benchmark(SimplexGrid, ndims; verbosity=verbosity)
+function benchmark(verbosity = 1)
 
-    # println(ratio(trial_estimate_rectangle, trial_estimate_simplex))
-    println(
-        "RectangleGrid vs SimplexGrid: ",
-        judge(median(trial_rectangle), median(trial_simplex))
-    )
-    println("##################################################\n")
+    for ndims in 1:6
+
+        println("\n##################################################")
+        println("### Benchmark for ndims = $(ndims)")
+        println("##################################################")
+
+        trial_rectangle = benchmark_interpolate(RectangleGrid, ndims; verbosity=verbosity)
+        trial_simplex = benchmark_interpolate(SimplexGrid, ndims; verbosity=verbosity)
+
+        # println(ratio(trial_estimate_rectangle, trial_estimate_simplex))
+        println(
+            "RectangleGrid vs SimplexGrid: ",
+            judge(median(trial_rectangle), median(trial_simplex))
+        )
+
+        println("ind2x:", benchmark_ind2x())
+        println("##################################################\n")
+
+
+    end
 
 end
+
+benchmark()

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -108,11 +108,11 @@ function Base.show(io::IO, grid::AbstractGrid)
     end
 end
 
-function ind2x(grid::AbstractGrid, ind::Int)
+function ind2x(grid::AbstractGrid{D}, ind::Int) where D
     ndims = dimensions(grid)
-    x = Array{Float64}(undef, ndims)
+    x::MVector{D, Float64} = @MVector zeros(D)
     ind2x!(grid, ind, x)
-    x::Array{Float64}
+    x::MVector{D, Float64}
 end
 
 function ind2x!(grid::AbstractGrid, ind::Int, x::AbstractArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,7 +99,7 @@ function compareToGrid(testType::Symbol=:random, numDims::Int=3, pointsPerDim::I
 
 end
 
-function getFractionalIndexes(g::AbstractGrid, s::Array)
+function getFractionalIndexes(g::AbstractGrid, s::AbstractArray)
     # Returns the fractional index of sprime within the grid-defined discretization.
 
     fracInd = Array{Int64}(undef, length(g.cutPoints))


### PR DESCRIPTION
It seems that pre-specifying the vector size using `MVector` from `StaticArrays` helps to significantly improve the performance of `ind2x`
![Screenshot from 2020-03-05 23-57-18](https://user-images.githubusercontent.com/53627988/76033769-e9270800-5ef1-11ea-991e-6bad4c0ee539.png)
