### PR TITLE
Remove allocations in interpolants(grid::RectangleGrid, x::AbstractVector) and interpolate using view

### DIFF
--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -159,11 +159,11 @@ interpolate(grid::AbstractGrid, data::Matrix, x::AbstractVector) = interpolate(g
 
 function interpolate(grid::AbstractGrid, data::DenseArray, x::AbstractVector)
     index, weight = interpolants(grid, x)
-	v = 0.0
-	for (i,data_ind) in enumerate(index)
-		v += data[data_ind]*weight[i]
-	end
-	return v
+    v = 0.0
+    for (i,data_ind) in enumerate(index)
+        v += data[data_ind]*weight[i]
+    end
+    return v
 end
 
 function interpolants(grid::RectangleGrid, x::AbstractVector)
@@ -230,8 +230,8 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
         subblock_size = subblock_size*(cut_counts[d])
     end
 
-	v = min(l,length(grid.index))
-	return view(grid.index,1:v),view(grid.weight,1:v)
+    v = min(l,length(grid.index))
+    return view(grid.index,1:v),view(grid.weight,1:v)
 end
 
 function interpolants(grid::SimplexGrid, x::AbstractVector)

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -159,7 +159,11 @@ interpolate(grid::AbstractGrid, data::Matrix, x::AbstractVector) = interpolate(g
 
 function interpolate(grid::AbstractGrid, data::DenseArray, x::AbstractVector)
     index, weight = interpolants(grid, x)
-    dot(data[index], weight)
+	v = 0.0
+	for (i,data_ind) in enumerate(index)
+		v += data[data_ind]*weight[i]
+	end
+	return v
 end
 
 function interpolants(grid::RectangleGrid, x::AbstractVector)
@@ -226,11 +230,8 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
         subblock_size = subblock_size*(cut_counts[d])
     end
 
-    if l<length(grid.index)
-        # This is true if we don't need to interpolate all dimensions because we're on a boundary:
-        return grid.index[1:l]::Vector{Int}, grid.weight[1:l]::Vector{Float64}
-    end
-    grid.index::Vector{Int}, grid.weight::Vector{Float64}
+	v = min(l,length(grid.index))
+	return view(grid.index,1:v),view(grid.weight,1:v)
 end
 
 function interpolants(grid::SimplexGrid, x::AbstractVector)
@@ -350,7 +351,7 @@ function vertices(grid::AbstractGrid)
 
     #=
     This relies on the memory layout of Matrix to stay the same, so is a
-    possible source of future errors. However, it is documented 
+    possible source of future errors. However, it is documented
     (http://juliaarrays.github.io/StaticArrays.jl/stable/pages/
     api.html#Arrays-of-static-arrays-1), and tests should catch these errors.
     =#


### PR DESCRIPTION
1) Modified the interpolants function to return a view of grid.index and grid.weight instead of slicing it (gets rid of allocations).
2) Modified the interpolate function to avoid allocation (data[index] was causing allocations). 

**Performance comparison**

Before these modifications

![Screenshot from 2023-12-12 15-46-11](https://github.com/sisl/GridInterpolations.jl/assets/57426103/a9603089-99fe-4d1d-9b1a-f073891b3d1b)

After these modifications

![Screenshot from 2023-12-12 15-46-43](https://github.com/sisl/GridInterpolations.jl/assets/57426103/d138e7b3-3c3b-47d4-98fc-1a8778bee599)


If there are any issues with it, please let me know. Thanks! 