### PR TITLE
SVector interpolants

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ julia> for x in grid
        end
 ```
 
+## Limitations
+
+`RectangleGrid` will error in high-dimensional domains (above about 15). In these cases `SimplexGrid` should be used.
+
 ## Credits
 
 Contributors to this package include Maxim Egorov, Eric Mueller, and Mykel Kochenderfer.

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -203,12 +203,12 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
                 @inbounds index2[i  ] = index[i] + (i_lo-cut_i)*subblock_size
                 @inbounds index2[i+l] = index[i] + (i_hi-cut_i)*subblock_size
             end
-            copyto!(index, index2)
+            @inbounds index[:] = index2
             for i = 1:l
                 @inbounds weight2[i  ] = weight[i]*low
                 @inbounds weight2[i+l] = weight[i]*(1-low)
             end
-            copyto!(weight, weight2)
+            @inbounds weight[:] = weight2
             l = l*2
             n = n*2
         end
@@ -315,7 +315,7 @@ function interpolants(grid::SimplexGrid, x::AbstractVector)
 
     weight = weight ./ sum(weight)
 
-    return index, weight
+    return SVector(index), SVector(weight)
 end
 
 "Return a vector of SVectors where the ith vector represents the vertex corresponding to the ith index of grid data."

--- a/src/GridInterpolations.jl
+++ b/src/GridInterpolations.jl
@@ -12,10 +12,6 @@ mutable struct RectangleGrid{D} <: AbstractGrid{D}
     cutPoints::Vector{Vector{Float64}}
     cut_counts::Vector{Int}
     cuts::Vector{Float64}
-    index::Vector{Int}
-    weight::Vector{Float64}
-    index2::Vector{Int}
-    weight2::Vector{Float64}
 
     function RectangleGrid{D}(cutPoints...) where D
         cut_counts = Int[length(cutPoints[i]) for i = 1:length(cutPoints)]
@@ -32,15 +28,7 @@ mutable struct RectangleGrid{D} <: AbstractGrid{D}
             end
             myCutPoints[i] = cutPoints[i]
         end
-        index = zeros(Int, 2^numDims)
-        weight = zeros(Float64, 2^numDims)
-        index[1] = 1
-        weight[1] = 1.0
-        index2 = zeros(Int, 2^numDims)
-        weight2 = zeros(Float64, 2^numDims)
-        index2[1] = 1
-        weight2[1] = 1.0
-        return new(myCutPoints, cut_counts, cuts, index, weight, index2, weight2)
+        return new(myCutPoints, cut_counts, cuts)
     end
 end
 
@@ -50,8 +38,6 @@ mutable struct SimplexGrid{D} <: AbstractGrid{D}
     cutPoints::Vector{Vector{Float64}}
     cut_counts::Vector{Int}
     cuts::Vector{Float64}
-    index::Vector{Int}
-    weight::Vector{Float64}
     x_p::Vector{Float64} # residuals
     ihi::Vector{Int} # indices of cuts above point
     ilo::Vector{Int} # indices of cuts below point
@@ -72,13 +58,11 @@ mutable struct SimplexGrid{D} <: AbstractGrid{D}
             end
             myCutPoints[i] = cutPoints[i]
         end
-        index = zeros(Int, numDims+1) # d+1 points for simplex
-        weight = zeros(Float64, numDims+1)
         x_p = zeros(numDims) # residuals
         ihi = zeros(Int, numDims) # indicies of cuts above point
         ilo = zeros(Int, numDims) # indicies of cuts below point
         n_ind = zeros(Int, numDims)
-        return new(myCutPoints, cut_counts, cuts, index, weight, x_p, ihi, ilo, n_ind)
+        return new(myCutPoints, cut_counts, cuts, x_p, ihi, ilo, n_ind)
     end
 end
 
@@ -179,14 +163,6 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
     index2 = @MVector(ones(Int, 2^dimensions(grid)))
     weight = @MVector(zeros(eltype(x), 2^dimensions(grid)))
     weight2 = @MVector(zeros(eltype(x), 2^dimensions(grid)))
-    # index = MVector{2^dimensions(grid), Int}(undef)
-    # index2 = MVector{2^dimensions(grid), Int}(undef)
-    # weight = MVector{2^dimensions(grid), eltype(x)}(undef)
-    # weight2 = MVector{2^dimensions(grid), eltype(x)}(undef)
-    # fill!(index,1)
-    # fill!(index2,1)
-    # fill!(weight,0)
-    # fill!(weight2,0)
     index[1] = 1
     index2[1] = 1
     weight[1] = one(eltype(weight))
@@ -227,12 +203,12 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
                 @inbounds index2[i  ] = index[i] + (i_lo-cut_i)*subblock_size
                 @inbounds index2[i+l] = index[i] + (i_hi-cut_i)*subblock_size
             end
-            index[:] = index2
+            copyto!(index, index2)
             for i = 1:l
                 @inbounds weight2[i  ] = weight[i]*low
                 @inbounds weight2[i+l] = weight[i]*(1-low)
             end
-            weight[:] = weight2
+            copyto!(weight, weight2)
             l = l*2
             n = n*2
         end
@@ -242,13 +218,12 @@ function interpolants(grid::RectangleGrid, x::AbstractVector)
 
     v = min(l,length(index))
     return view(SVector(index),1:v), view(SVector(weight),1:v)
-    # return SVector(index), SVector(weight)
 end
 
 function interpolants(grid::SimplexGrid, x::AbstractVector)
 
-    weight = grid.weight
-    index  = grid.index
+    weight = MVector{dimensions(grid)+1, eltype(x)}(undef)
+    index  = MVector{dimensions(grid)+1, Int}(undef)
 
     x_p = grid.x_p # residuals
     ihi = grid.ihi # indicies of cuts above point
@@ -340,7 +315,7 @@ function interpolants(grid::SimplexGrid, x::AbstractVector)
 
     weight = weight ./ sum(weight)
 
-    return index::Vector{Int}, weight::Vector{Float64}
+    return index, weight
 end
 
 "Return a vector of SVectors where the ith vector represents the vertex corresponding to the ith index of grid data."


### PR DESCRIPTION
This is an alternative to #43

It actually makes a significant change. Previously, the memory for the interpolants was cached in the grid object. This creates new static arrays with every call to `interpolants`.

Conceptually, this is a big improvement because previously, if you called interpolants, stored the results without copying, and then called interpolants again, it would overwrite the original interpolants! yikes!

Here are some new results:
```julia
using GridInterpolations
using BenchmarkTools

grid_data = [8.0, 1.0, 6.0, 3.0, 5.0, 7.0, 4.0, 9.0, 2.0]
x = [0.25, 0.75]

grid = RectangleGrid([0.0, 0.5, 1.0], [0.0, 0.5, 1.0]) # Float64
@btime interpolate($grid, $grid_data, $x)
#   33.782 ns (0 allocations: 0 bytes)

using ForwardDiff
f(x::Vector) = interpolate(grid, grid_data, x)
@btime ForwardDiff.gradient($f, $x)
#  635.357 ns (5 allocations: 320 bytes)
```

Unfortunately, there is a small regression in performance from the old way in some of the benchmarks from the tests

Old:
```
1000 interpolations of 6 dimensions with 15 cut points per dimension:
  Rectangle required 0.0009157518239999992 +/- 0.00023133335979010877 sec
  Simplex   required 0.0006389991239999997 +/- 0.0006475247064044843 sec
How large is the simplex grid speed up over the multilinear grid?
  limiting to 2 dimensions and therefore 316 points per dim:
    mean speed: 0.00031382153333333343, std dev: 6.616835029389875e-5
  limiting to 3 dimensions and therefore 46 points per dim:
    mean speed: 0.000284075, std dev: 6.0499168543730904e-5
  limiting to 4 dimensions and therefore 18 points per dim:
    mean speed: 0.0004026574000000001, std dev: 8.200233409226417e-5
  limiting to 5 dimensions and therefore 10 points per dim:
    mean speed: 0.0004601372666666666, std dev: 8.407939234160375e-5
100 interpolations of 4 dimensions with 10 cut points per dimension:
  Rectangle required 0.00022583938999999994 +/- 4.003089883334692e-5 sec
  Simplex   required 0.0003840863899999998 +/- 5.763477849382195e-5 sec
```
New:
```
1000 interpolations of 6 dimensions with 15 cut points per dimension:
  Rectangle required 0.0010046940880000007 +/- 0.0008021641712052207 sec
  Simplex   required 0.0005958515850000009 +/- 0.0007433027770190067 sec
How large is the simplex grid speed up over the multilinear grid?
  limiting to 2 dimensions and therefore 316 points per dim:
    mean speed: 0.0003624577666666666, std dev: 4.106958632297421e-5
  limiting to 3 dimensions and therefore 46 points per dim:
    mean speed: 0.0002571071666666667, std dev: 5.565465236576383e-5
  limiting to 4 dimensions and therefore 18 points per dim:
    mean speed: 0.0003611892, std dev: 6.304453687157774e-5
  limiting to 5 dimensions and therefore 10 points per dim:
    mean speed: 0.00041827066666666663, std dev: 5.4756525932804423e-5
100 interpolations of 4 dimensions with 10 cut points per dimension:
  Rectangle required 0.00032039601999999995 +/- 0.0009210866573612322 sec
  Simplex   required 0.00033461859999999995 +/- 4.617121162356343e-5 sec
```

I think the new safer and easier-to-understand code is well worth it.